### PR TITLE
Allow "0 inches" in heights for Position Calculator

### DIFF
--- a/src/views/PositionCalculator.vue
+++ b/src/views/PositionCalculator.vue
@@ -204,7 +204,7 @@ export default {
     submit(event) {
       event.preventDefault();
       try {
-        if ((this.htFt || this.htFt === '0') && (this.htIn || this.htIn === '0')) {
+        if ((this.htFt || this.htFt === 0) && (this.htIn || this.htIn === 0)) {
           this.player.height = 2.54 * (12 * this.htFt + +this.htIn);
         } else if (this.htCm) {
           this.player.height = +this.htCm;


### PR DESCRIPTION
I noticed that, when you try to get position ratings for a player who's e.g. 6'0", that you do not get a 1B rating back.

I've never used Vue before, but after poking at in in the debugger a bit it appears that the `htFt` and `htIn` fields are _already_ numbers at the point that `submit` fires,, so the `htIn === '0'` check fails.

This works for me to get those heights recognized properly.